### PR TITLE
Improve CacheRepo capabilities

### DIFF
--- a/src/api/tokio/download.rs
+++ b/src/api/tokio/download.rs
@@ -216,13 +216,15 @@ impl ApiRepo {
     /// ```
     pub async fn info(&self) -> Result<RepoInfo, ApiError> {
         println!("Getting info for repo");
-        let result = self.api.cache.repo(self.repo.clone()).info();
-        let repo_info = RepoInfo {
-            siblings: result.unwrap(),
-            sha: "".to_string(),
-        };
-        Ok(repo_info)
-        // Ok(self.info_request().send().await?.json().await?)
+        if let Some(result) = self.api.cache.repo(self.repo.clone()).info() {
+            let repo_info = RepoInfo {
+                siblings: result,
+                sha: "".to_string(),
+            };
+            Ok(repo_info)
+        } else {
+            Ok(self.info_request().send().await?.json().await?)
+        }
     }
 
     /// Get the raw [`reqwest::RequestBuilder`] with the url and method already set

--- a/src/api/tokio/download.rs
+++ b/src/api/tokio/download.rs
@@ -215,7 +215,14 @@ impl ApiRepo {
     /// # })
     /// ```
     pub async fn info(&self) -> Result<RepoInfo, ApiError> {
-        Ok(self.info_request().send().await?.json().await?)
+        println!("Getting info for repo");
+        let result = self.api.cache.repo(self.repo.clone()).info();
+        let repo_info = RepoInfo {
+            siblings: result.unwrap(),
+            sha: "".to_string(),
+        };
+        Ok(repo_info)
+        // Ok(self.info_request().send().await?.json().await?)
     }
 
     /// Get the raw [`reqwest::RequestBuilder`] with the url and method already set

--- a/src/api/tokio/download.rs
+++ b/src/api/tokio/download.rs
@@ -215,16 +215,16 @@ impl ApiRepo {
     /// # })
     /// ```
     pub async fn info(&self) -> Result<RepoInfo, ApiError> {
-        println!("Getting info for repo");
         if let Some(result) = self.api.cache.repo(self.repo.clone()).info() {
-            let repo_info = RepoInfo {
-                siblings: result,
-                sha: "".to_string(),
-            };
-            Ok(repo_info)
+            Ok(result)
         } else {
             Ok(self.info_request().send().await?.json().await?)
         }
+    }
+
+    /// Mark a model download as complete to ensure that is in the cache and is complete.
+    pub fn mark_download_as_complete(&self) -> Result<(), std::io::Error> {
+        self.api.cache.repo(self.repo.clone()).write_sanity_file()
     }
 
     /// Get the raw [`reqwest::RequestBuilder`] with the url and method already set

--- a/src/api/tokio/mod.rs
+++ b/src/api/tokio/mod.rs
@@ -75,7 +75,7 @@ impl std::error::Error for ReqwestErrorWithBody {}
 ///
 ///     // Will return Err with both the error and response body if status code is not successful
 ///     let response = response.maybe_err().await?;
-///     
+///
 ///     // Process successful response...
 ///     Ok(())
 /// }

--- a/src/api/tokio/upload/lfs.rs
+++ b/src/api/tokio/upload/lfs.rs
@@ -31,7 +31,7 @@ pub struct BatchObject {
 
 #[derive(Debug, Deserialize)]
 pub struct BatchError {
-    pub code: i32,
+    pub _code: i32,
     pub message: String,
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,10 +1,13 @@
-#![deny(missing_docs)]
 #![doc = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/README.md"))]
 #[cfg(any(feature = "tokio", feature = "ureq"))]
 use rand::{distributions::Alphanumeric, Rng};
 use std::io::Write;
 use std::path::PathBuf;
 use std::str::FromStr;
+use tokio::fs::read_dir;
+
+use crate::api::tokio::ApiError;
+use crate::api::Siblings;
 
 /// The actual Api to interact with the hub.
 #[cfg(any(feature = "tokio", feature = "ureq"))]
@@ -172,6 +175,23 @@ impl CacheRepo {
         } else {
             None
         }
+    }
+
+    fn info(&self) -> Result<Vec<Siblings>, ApiError> {
+        let mut info = vec![];
+        let commit_path = self.ref_path();
+        let commit_hash = std::fs::read_to_string(commit_path).ok().unwrap();
+        let pointer_path = self.pointer_path(&commit_hash);
+        let paths = std::fs::read_dir(pointer_path).unwrap();
+        for path_result in paths {
+            let full_path = path_result?.path();
+            let file_name = full_path.file_name().unwrap().to_str().unwrap().to_string();
+            let sibling = Siblings {
+                rfilename: file_name,
+            };
+            info.push(sibling);
+        }
+        Ok(info)
     }
 
     fn path(&self) -> PathBuf {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,7 @@ use std::path::PathBuf;
 use std::str::FromStr;
 use tokio::fs::read_dir;
 
-use crate::api::tokio::ApiError;
+use crate::api::sync::ApiError;
 use crate::api::Siblings;
 
 /// The actual Api to interact with the hub.
@@ -177,21 +177,28 @@ impl CacheRepo {
         }
     }
 
-    fn info(&self) -> Result<Vec<Siblings>, ApiError> {
+    fn info(&self) -> Option<Vec<Siblings>> {
         let mut info = vec![];
         let commit_path = self.ref_path();
-        let commit_hash = std::fs::read_to_string(commit_path).ok().unwrap();
+        let commit_hash = std::fs::read_to_string(commit_path).ok()?;
         let pointer_path = self.pointer_path(&commit_hash);
-        let paths = std::fs::read_dir(pointer_path).unwrap();
+        let paths = std::fs::read_dir(pointer_path).ok()?;
         for path_result in paths {
-            let full_path = path_result?.path();
-            let file_name = full_path.file_name().unwrap().to_str().unwrap().to_string();
+            let full_path = path_result.ok()?.path();
+            let file_name = full_path
+                .file_name()
+                .map(|name| name.to_str().unwrap().to_string())
+                .unwrap();
             let sibling = Siblings {
                 rfilename: file_name,
             };
             info.push(sibling);
         }
-        Ok(info)
+        if info.is_empty() {
+            None
+        } else {
+            Some(info)
+        }
     }
 
     fn path(&self) -> PathBuf {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,15 +4,14 @@ use rand::{distributions::Alphanumeric, Rng};
 use std::io::Write;
 use std::path::PathBuf;
 use std::str::FromStr;
-use tokio::fs::read_dir;
 
-use crate::api::sync::ApiError;
-use crate::api::Siblings;
+use crate::api::{RepoInfo, Siblings};
 
 /// The actual Api to interact with the hub.
 #[cfg(any(feature = "tokio", feature = "ureq"))]
 pub mod api;
 
+pub const COMPLETE_DOWNLOAD_FILE: &str = ".download_complete";
 /// The type of repo to interact with
 #[derive(Debug, Clone, Copy)]
 pub enum RepoType {
@@ -177,28 +176,62 @@ impl CacheRepo {
         }
     }
 
-    fn info(&self) -> Option<Vec<Siblings>> {
-        let mut info = vec![];
+    fn info(&self) -> Option<RepoInfo> {
         let commit_path = self.ref_path();
         let commit_hash = std::fs::read_to_string(commit_path).ok()?;
         let pointer_path = self.pointer_path(&commit_hash);
-        let paths = std::fs::read_dir(pointer_path).ok()?;
-        for path_result in paths {
-            let full_path = path_result.ok()?.path();
-            let file_name = full_path
-                .file_name()
-                .map(|name| name.to_str().unwrap().to_string())
-                .unwrap();
-            let sibling = Siblings {
-                rfilename: file_name,
-            };
-            info.push(sibling);
+        let entries: Vec<_> = std::fs::read_dir(&pointer_path).ok()?.collect();
+
+        let download_verified = entries.iter().any(|entry| {
+            if let Ok(entry) = entry {
+                if let Some(name) = entry.file_name().to_str() {
+                    return name.starts_with(COMPLETE_DOWNLOAD_FILE);
+                }
+            }
+            false
+        });
+
+        if !download_verified {
+            log::warn!(
+                "Download could not be verified for commit {commit_hash} in repo {}",
+                self.repo.repo_id
+            );
+            return None;
         }
-        if info.is_empty() {
+
+        let siblings: Vec<Siblings> = entries
+            .into_iter()
+            .filter_map(|entry| {
+                let entry = entry.ok()?;
+                let file_name = entry.file_name().to_str()?.to_string();
+                Some(Siblings {
+                    rfilename: file_name,
+                })
+            })
+            .collect();
+
+        if siblings.is_empty() {
             None
         } else {
-            Some(info)
+            Some(RepoInfo {
+                siblings,
+                sha: commit_hash,
+            })
         }
+    }
+
+    fn write_sanity_file(&self) -> Result<(), std::io::Error> {
+        let commit_path = self.ref_path();
+        let commit_hash = std::fs::read_to_string(commit_path)?;
+        let verification_file = self
+            .cache
+            .path()
+            .join(self.repo.folder_name())
+            .join("snapshots")
+            .join(&commit_hash)
+            .join(COMPLETE_DOWNLOAD_FILE);
+        std::fs::File::create(verification_file)?;
+        Ok(())
     }
 
     fn path(&self) -> PathBuf {


### PR DESCRIPTION
- Add the `info` function to the CacheRepo to get all siblings from the cache instead of hitting the HuggingFace API
- Add a new function to mark a download as complete in the cache, that way we know the cache is valid and all the downloaded model is complete